### PR TITLE
Support for Service Bus Deferrals

### DIFF
--- a/src/Cloud.Core/IMessenger.cs
+++ b/src/Cloud.Core/IMessenger.cs
@@ -49,6 +49,14 @@
         IDictionary<string, object> ReadProperties<T>(T msg) where T : class;
 
         /// <summary>
+        /// Read system properties from a message.
+        /// </summary>
+        /// <typeparam name="T">Type T of message.</typeparam>
+        /// <param name="msg">Message body, used to identity the message to read from.</param>
+        /// <returns>Dictionary of string, object system properties.</returns>
+        IDictionary<string, object> ReadSystemProperties<T>(T msg) where T : class;
+
+        /// <summary>
         /// Completes the message and removes from the queue.
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/src/Cloud.Core/IMessenger.cs
+++ b/src/Cloud.Core/IMessenger.cs
@@ -49,14 +49,6 @@
         IDictionary<string, object> ReadProperties<T>(T msg) where T : class;
 
         /// <summary>
-        /// Read system properties from a message.
-        /// </summary>
-        /// <typeparam name="T">Type T of message.</typeparam>
-        /// <param name="msg">Message body, used to identity the message to read from.</param>
-        /// <returns>Dictionary of string, object system properties.</returns>
-        IDictionary<string, object> ReadSystemProperties<T>(T msg) where T : class;
-
-        /// <summary>
         /// Completes the message and removes from the queue.
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/src/Cloud.Core/IMessenger.cs
+++ b/src/Cloud.Core/IMessenger.cs
@@ -82,6 +82,31 @@
         Task Abandon<T>(T message, KeyValuePair<string, object>[] propertiesToModify = null) where T : class;
 
         /// <summary>
+        /// Defers a message in the the queue.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="message">The message we want to abandon.</param>
+        /// <param name="propertiesToModify">The message properties to modify on abandon.</param>
+        /// <returns>The async <see cref="Task" /> wrapper.</returns>
+        Task Defer<T>(T message, KeyValuePair<string, object>[] propertiesToModify = null) where T : class;
+
+        /// <summary>
+        /// Receives a batch of deferred messages of type T.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="sequenceNumbers">The list of sequence numbers pertaining to the batch</param>
+        /// <returns>IMessageItem&lt;T&gt;.</returns>
+        Task<List<T>> ReceiveDeferredBatch<T>(IEnumerable<long> sequenceNumbers) where T : class;
+
+        /// <summary>
+        /// Receives a batch of deferred messages of type IMessageEntity types.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="sequenceNumbers">The list of sequence numbers pertaining to the batch</param>
+        /// <returns>IMessageEntity&lt;T&gt;.</returns>
+        Task<List<IMessageEntity<T>>> ReceiveDeferredBatchEntity<T>(IEnumerable<long> sequenceNumbers) where T : class;
+
+        /// <summary>
         /// Errors a message by moving it specifically to the error queue (dead-letter).
         /// </summary>
         /// <typeparam name="T"></typeparam>

--- a/src/Cloud.Core/IMessenger.cs
+++ b/src/Cloud.Core/IMessenger.cs
@@ -69,8 +69,9 @@
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="message">The message we want to abandon.</param>
+        /// <param name="propertiesToModify">The message properties to modify on abandon.</param>
         /// <returns>The async <see cref="Task" /> wrapper.</returns>
-        Task Abandon<T>(T message) where T : class;
+        Task Abandon<T>(T message, KeyValuePair<string, object>[] propertiesToModify = null) where T : class;
 
         /// <summary>
         /// Errors a message by moving it specifically to the error queue (dead-letter).


### PR DESCRIPTION
Hi Rob,

I'm looking to open up Cloud.Core up to support service bus deferrals. That is setting a message to deferred state on service bus, access to system properties in order to obtain the message sequence number, and obtaining messages again using the list of matching sequence number.

I only need access to sequence number right now but thought it may be useful to allow access to allow. Would this be an issue?

Finally, I also need to be able to set properties on abandon so have modified message operations accordingly.

Thanks
Keith 